### PR TITLE
Pin jsonschema version < 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ simplejson>=3.6.5
 sh>=1.11
 pycryptodome
 cryptography>=0.8
-jsonschema>=2.4.0
+jsonschema>=2.4.0,<3.0
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description='Configuration Processor for Ardana CLM',
     long_description=open('README.txt').read(),
     install_requires=['six', 'stevedore', 'netaddr', 'pycryptodome',
-                      'cryptography', 'simplejson', 'jsonschema', 'html',
+                      'cryptography', 'simplejson', 'jsonschema>=2.4,<3.0', 'html',
                       'PyYAML', 'pbs' if os.name == 'nt' else 'sh'],
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
in development jsonschema 3.0 gets installed in venvs. I believe some modules were re organized in 3.0 causing module reference errors.